### PR TITLE
Version 0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ main.js.map
 .idea
 npm-debug.log.*
 .vscode/settings.json
+electron-builder.yml

--- a/Changelog.md
+++ b/Changelog.md
@@ -8,6 +8,10 @@
 - Fixed a bug which caused newly imported folders to not update in the viewer page until another action was made
 - Fixed a bug causing thumbnails to not refresh after background app
 - Fixed a bug causing the export "Open" button being unable to find a written file when exporting multiple
+- Fixed a crash when navigating the viewer into an RSML without an image
+- Fixed mutliple crashes and exceptions relating to refreshing the gallery page
+- Added tooltip to explain why images are being skipped in viewer page
+- Fixed crash where deleting an image from the file system and then refreshing would crash viewer if that image was currently open.
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,8 @@
 - Added separator to icon menu.
 - Re-added missing util function `splitLinesAsPlants`.
 - Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
+- Fixed potential crash when importing non .js plugins.
+- Added type checking for plugins.
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,10 +1,12 @@
 # Next Release:
+- Added auto-updates for Windows
+- Added an 'About' page to document maintainer contacts, suggestion/bug link, version and internals
+- Added type checking for plugins.
 - Modified message dialog when closing the gallery while images are still processing.
 - Added separator to icon menu.
 - Re-added missing util function `splitLinesAsPlants`.
 - Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
 - Fixed potential crash when importing non .js plugins.
-- Added type checking for plugins.
 - Fixed a bug which caused newly imported folders to not update in the viewer page until another action was made
 - Fixed a bug causing thumbnails to not refresh after background app
 - Fixed a bug causing the export "Open" button being unable to find a written file when exporting multiple

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
 - Fixed potential crash when importing non .js plugins.
 - Added type checking for plugins.
+- Fixed a bug which caused newly imported folders to not update in the viewer page until another action was made
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,8 @@
 - Fixed potential crash when importing non .js plugins.
 - Added type checking for plugins.
 - Fixed a bug which caused newly imported folders to not update in the viewer page until another action was made
+- Fixed a bug causing thumbnails to not refresh after background app
+- Fixed a bug causing the export "Open" button being unable to find a written file when exporting multiple
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,4 @@
-# Next Release:
+# 0.6.0:
 - Added auto-updates for Windows. App will download, notify, and update on close
 - Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
 - Added an 'About' page to document maintainer contacts, suggestion/bug link, version and internals

--- a/Changelog.md
+++ b/Changelog.md
@@ -13,7 +13,8 @@
 - Fixed a crash when navigating the viewer into an RSML without an image
 - Fixed mutliple crashes and exceptions relating to refreshing the gallery page
 - Added tooltip to explain why images are being skipped in viewer page
-- Fixed crash where deleting an image from the file system and then refreshing would crash viewer if that image was currently open.
+- Fixed crash where deleting an image from the file system and then refreshing would crash viewer if that image was currently open
+- Fixed bug when switching folders in the viewer can crash if the first tag has no image or RSML
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,21 +1,21 @@
 # Next Release:
-- Added auto-updates for Windows
+- Added auto-updates for Windows. App will download, notify, and update on close
+- Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
 - Added an 'About' page to document maintainer contacts, suggestion/bug link, version and internals
+- Added 'Open Viewer' button to gallery, and added state to viewer if nothing is open.
 - Added type checking for plugins.
 - Modified message dialog when closing the gallery while images are still processing.
 - Added separator to icon menu.
 - Re-added missing util function `splitLinesAsPlants`.
-- Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
+- Added tooltip to explain why images are being skipped in viewer page
 - Fixed potential crash when importing non .js plugins.
 - Fixed a bug which caused newly imported folders to not update in the viewer page until another action was made
 - Fixed a bug causing thumbnails to not refresh after background app
 - Fixed a bug causing the export "Open" button being unable to find a written file when exporting multiple
 - Fixed a crash when navigating the viewer into an RSML without an image
 - Fixed mutliple crashes and exceptions relating to refreshing the gallery page
-- Added tooltip to explain why images are being skipped in viewer page
 - Fixed crash where deleting an image from the file system and then refreshing would crash viewer if that image was currently open
 - Fixed bug when switching folders in the viewer can crash if the first tag has no image or RSML
-- Added 'Open Viewer' button to gallery, and added state to viewer if nothing is open.
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -15,6 +15,7 @@
 - Added tooltip to explain why images are being skipped in viewer page
 - Fixed crash where deleting an image from the file system and then refreshing would crash viewer if that image was currently open
 - Fixed bug when switching folders in the viewer can crash if the first tag has no image or RSML
+- Added 'Open Viewer' button to gallery, and added state to viewer if nothing is open.
 
 # 0.5.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,8 @@
-# 0.5.1
+# Next Release:
 - Modified message dialog when closing the gallery while images are still processing.
 - Added separator to icon menu.
 - Re-added missing util function `splitLinesAsPlants`.
+- Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
 
 # 0.5.0
 

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -58,8 +58,8 @@ export default class Routes extends Component {
     }
 
     static View(props) {
-        let { page = "", path = "", exts = "" } = props.location.search.match(/(?<page>\?[^?]+)\??(?<path>[^|]+)?\|?(?<exts>.+)?/).groups //This matches the passed URL into 3 groups - ?viewer, ?folder/filepath, and |rsml|png|etc. The negated sets are to delimit the capture groups
-        path = path.replace(/%20/g, " "); //Replace any encoded spaces in the file path with a space.
+        let { page = "", path, exts = "" } = props.location.search.match(/(?<page>\?[^?]+)\??(?<path>[^|]+)?\|?(?<exts>.+)?/).groups //This matches the passed URL into 3 groups - ?viewer, ?folder/filepath, and |rsml|png|etc. The negated sets are to delimit the capture groups
+        path = path ? path.replace(/%20/g, " ") : path; //Replace any encoded spaces in the file path with a space.
         exts = exts.split('|');
 
         return Routes.Views(path, exts)[page] || Routes.Views()[routes.HOME];

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -160,12 +160,12 @@ export default class Routes extends Component {
                 {
                     label: "&Server Settings",
                     accelerator: 'Ctrl+P',
-                    click: () => this.props.updateAPIModal(true)
+                    click: () => { this.props.updateAPIModal(true); this.setState({ infoModal: false }) }
                 },
                 {
                     label: "&About",
                     accelerator: 'Ctrl+I',
-                    click: () => this.setState({ infoModal: true })
+                    click: () => { this.setState({ infoModal: true }); this.props.updateAPIModal(false) }
                 }
             ]
         },

--- a/app/Routes.js
+++ b/app/Routes.js
@@ -12,6 +12,9 @@ import { Button, Modal, InputGroup, Collapse } from 'react-bootstrap';
 import { writeConfig, _require } from './constants/globals';
 import styled from 'styled-components';
 const { Menu } = remote;
+import os from 'os';
+import { exec } from 'child_process';
+
 export default class Routes extends Component {
 
     StyledPort = styled.input`
@@ -31,7 +34,7 @@ export default class Routes extends Component {
     constructor(props)
     {
         super(props);
-        this.state = { openCollapse: false, changeSaveAnimation: false, validateWarning: false };
+        this.state = { openCollapse: false, changeSaveAnimation: false, validateWarning: false, infoModal: false };
 
         const menu = Menu.buildFromTemplate(this.menuTemplate);
         remote.getCurrentWindow().setMenu(menu);
@@ -59,10 +62,7 @@ export default class Routes extends Component {
         path = path.replace(/%20/g, " "); //Replace any encoded spaces in the file path with a space.
         exts = exts.split('|');
 
-        let view = Routes.Views(path, exts)[page];
-        if (view == null) 
-            view = Routes.Views()[routes.HOME];
-        return view;
+        return Routes.Views(path, exts)[page] || Routes.Views()[routes.HOME];
     }
 
     saveSettings = () => {
@@ -120,6 +120,34 @@ export default class Routes extends Component {
                         </Button>
                     </Modal.Footer>
                 </Modal> 
+
+                <Modal show={this.state.infoModal} onHide={() => this.setState({ infoModal: false })}>
+                    <Modal.Header closeButton>
+                        <Modal.Title>Application Info <span><this.StyledI style={{verticalAlign: 'text-top'}} className="fas fa-info-circle"/></span></Modal.Title>
+                    </Modal.Header>
+                    <Modal.Body>
+                        <b>RootNav Portal</b> version {remote.app.getVersion()}
+                        <br/><hr/>
+                        <b>Maintainers:</b>
+                        <ul>
+                            <li><b>Andrew Reynolds</b>: andrew.n64@hotmail.com</li>
+                            <li><b>Daniel Cordell</b>: danielbc@hotmail.co.uk</li>
+                            <li><b>Mike Pound</b>: sbzmpp@exmail.nottingham.ac.uk</li>
+                        </ul>
+                        For suggestions, feature requests or bug reports, please file an issue at <a style={{color: '#0000EE'}} onClick={() => exec(`${process.platform == 'win32' ? "start" : "open"} https://github.com/Chagrilled/RootNavPortal`)}>
+                            RootNav Portal's GitHub repository</a> or email a maintainer.
+                        <br/><hr/>
+                        <b>Electron</b>: {process.versions['electron']}<br/>
+                        <b>Chrome</b>: {process.versions['chrome']}<br/>
+                        <b>Node</b>: {process.versions['node']}<br/>
+                        <b>OS</b>: {`${os.type()} ${os.arch()} ${os.release()}`}
+                    </Modal.Body>
+                    <Modal.Footer>
+                        <Button variant="primary" onClick={() => this.setState({ infoModal: false })}>
+                            Close
+                        </Button>
+                    </Modal.Footer>
+                </Modal> 
             </div>
             </Router>
         );
@@ -127,14 +155,19 @@ export default class Routes extends Component {
 
     menuTemplate = [
         {
-            label: '&File',
+            label: '&Menu',
             submenu: [
                 {
                     label: "&Server Settings",
                     accelerator: 'Ctrl+P',
                     click: () => this.props.updateAPIModal(true)
+                },
+                {
+                    label: "&About",
+                    accelerator: 'Ctrl+I',
+                    click: () => this.setState({ infoModal: true })
                 }
             ]
-        }
+        },
     ];
 }

--- a/app/actions/galleryActions.js
+++ b/app/actions/galleryActions.js
@@ -9,6 +9,7 @@ export const IMPORT_CONFIG  = 'IMPORT_CONFIG';
 export const UPDATE_CHECKED = 'UPDATE_CHECKED';
 export const ADD_FILES      = 'ADD_FILES';
 export const ADD_THUMB      = 'ADD_THUMB';
+export const REMOVE_THUMB   = 'REMOVE_THUMB';
 export const UPDATE_FILTER_TEXT = 'UPDATE_FILTER_TEXT';
 export const UPDATE_FILTER_ANALYSED = 'UPDATE_FILTER_ANALYSED';
 export const UPDATE_PARSED_RSML = "UPDATE_PARSED_RSML";
@@ -34,6 +35,7 @@ export const importConfig  = (folders, apiAddress, apiKey)  => ({ type: IMPORT_C
 export const updateChecked = checked => ({ type: UPDATE_CHECKED, checked });
 export const addFiles      = (folder, files) => ({ type: ADD_FILES, folder, files });
 export const addThumb      = thumbs => ({ type: ADD_THUMB, thumbs }) //folder: full folder path string, fileName: file string, no ext
+export const removeThumb      = toRemove => ({ type: REMOVE_THUMB, toRemove }) //[{folder: folder1, filename: file1}, {folder: folder2, filename: file2},...]
 export const updateFilterText = text => ({ type: UPDATE_FILTER_TEXT, text });
 export const updateFilterAnalysed = checked => ({ type: UPDATE_FILTER_ANALYSED, checked });
 export const updateParsedRSML = newFiles => ({ type: UPDATE_PARSED_RSML, newFiles });

--- a/app/app.global.scss
+++ b/app/app.global.scss
@@ -111,10 +111,6 @@ p {
   font-size: 24px;
 }
 
-li {
-  list-style: none;
-}
-
 a {
   color: white;
   opacity: 0.75;

--- a/app/components/buttons/gallery/OpenViewerButton.js
+++ b/app/components/buttons/gallery/OpenViewerButton.js
@@ -1,0 +1,28 @@
+// @flow
+import React, { Component } from 'react';
+import { writeConfig, CLOSE_VIEWER } from '../../../constants/globals';
+import { StyledButton } from '../StyledComponents'; 
+import TooltipOverlay from '../../common/TooltipOverlay';
+import { ipcRenderer } from 'electron';
+
+export default class OpenViewerButton extends Component {
+
+    openViewer = () => {
+        ipcRenderer.send('openViewer', null);
+    }
+
+    render() { 
+        return <TooltipOverlay  component={ props => <StyledButton
+                variant="info"
+                className={`btn btn-default fas fa-chart-line button`}
+                onClick={e => {
+                    this.openViewer();
+                    e.stopPropagation()
+                }}
+                {...props}
+            />} 
+            text={"Open Viewer"}
+            placement={"bottom"}
+        /> 
+    }
+}

--- a/app/components/buttons/gallery/RefreshButton.js
+++ b/app/components/buttons/gallery/RefreshButton.js
@@ -5,34 +5,36 @@ import { StyledButton } from '../StyledComponents';
 import { readdir } from 'fs';
 import { sep } from 'path';
 import { ipcRenderer } from 'electron';
-import { ALL_EXTS_REGEX, API_PARSE, sendThumbs, _require, IMAGE_EXTS } from '../../../constants/globals'
+import { ALL_EXTS_REGEX, API_PARSE, sendThumbs, _require, IMAGE_EXTS, IMAGES_REMOVED_FROM_GALLERY  } from '../../../constants/globals'
 import TooltipOverlay from '../../common/TooltipOverlay';
 
 export default class RefreshButton extends Component {
 
     onClick = () => {
         let structuredFiles;
-        const { files, folders, refreshFiles, addThumbs, thumbs } = this.props;
+        let removeThumbnails;
+        const { files, folders, refreshFiles, removeThumbs, addThumbs, thumbs } = this.props;
         each(folders, (folder, callback) => {
             structuredFiles = {};
+            removeThumbnails = [];
             readdir(folder.path, (err, readFiles) => {
 				let matched = readFiles.map(file => file.match(ALL_EXTS_REGEX))
 					.filter(match => match) // Filter out null values, failed regex match.
                     .map(match => match.groups) //Scan for file types we use
                     .filter(regex => Object.keys(regex).length);
-
                 matched.forEach(regex => { //Structure of this array will be [original string, file name, file extension, some other stuff]
                     if (!structuredFiles[folder.path]) structuredFiles[folder.path] = {};
-                    if (files[folder.path][regex.fileName]) 
-                        structuredFiles[folder.path][regex.fileName] = files[folder.path][regex.fileName];
-                    else
-                    {
-                        let name = regex.fileName; //Each file has an object with the key as the file name
-						let ext  = regex.segMask ? regex.segMask.toUpperCase() : regex.ext.toLowerCase(); //if it's a seg mask like file_C1.png we'll get _C1, else we use the actual ext
-                        if (!structuredFiles[folder.path][name]) structuredFiles[folder.path][name] = {} // if there is rsml and the png you'll get filename: {rsml: true, png: true}
-						structuredFiles[folder.path][name][ext] = true; //This assumes filename stays consistent for variants of the file. They have to, else there'll be no link I guess. 2x check API behaviour on this.
-                    }
+                    let name = regex.fileName; //Each file has an object with the key as the file name
+                    let ext  = regex.segMask ? regex.segMask.toUpperCase() : regex.ext.toLowerCase(); //if it's a seg mask like file_C1.png we'll get _C1, else we use the actual ext
+                    if (!structuredFiles[folder.path][name]) structuredFiles[folder.path][name] = {} // if there is rsml and the png you'll get filename: {rsml: true, png: true}
+                    structuredFiles[folder.path][name][ext] = true; //This assumes filename stays consistent for variants of the file. They have to, else there'll be no link I guess. 2x check API behaviour on this.
                 });
+                // Remove old thumbnails that are no longer needed
+                Object.keys(structuredFiles[folder.path]).forEach(name => {
+                    if (Object.keys(files[folder.path][name]).some(key => IMAGE_EXTS.includes(key) && !Object.keys(structuredFiles[folder.path][name]).includes(key))) {
+                        removeThumbnails.push({folder: folder.path, filename: name});
+                    }
+                })
                 callback();
             });
         }, err => {
@@ -50,16 +52,20 @@ export default class RefreshButton extends Component {
                                 filesToParse.push(folder + sep + fileName); // Only parse if the folder has RSML, and it hasn't already been parsed!
                         });
                         if (filesToParse.length) ipcRenderer.send(API_PARSE, filesToParse); 
-                        
                         newThumbs = newThumbs.concat(Object.keys(files).map(fileName => {
-                            if (IMAGE_EXTS.some(ext => ext in structuredFiles[folder][fileName]) && !thumbs[folder][fileName])
+                            if (IMAGE_EXTS.some(ext => ext in structuredFiles[folder][fileName]) && thumbs && thumbs[folder] && !thumbs[folder][fileName])
                             {
                                 const { parsedRSML, _C1, _C2, rsml, ...exts } = structuredFiles[folder][fileName];
                                 return { folder, file: exts, fileName };
                             }
                         }));
                     });
-                    sendThumbs(newThumbs.filter(item => item !== undefined), addThumbs);
+                    if (newThumbs.length)
+                        sendThumbs(newThumbs.filter(item => item !== undefined), addThumbs);
+                    if (removeThumbnails.length) {
+                        ipcRenderer.send(IMAGES_REMOVED_FROM_GALLERY, removeThumbnails);
+                        removeThumbs(removeThumbnails); // Remove old thumbnails.
+                    }
                 }
             }
         });

--- a/app/components/buttons/gallery/ServerIndicator.js
+++ b/app/components/buttons/gallery/ServerIndicator.js
@@ -33,7 +33,7 @@ export default class ServerIndicator extends Component {
                     this.props.updateAPIModal(true);
                     e.stopPropagation()
                 }}      
-                style={{ transition: '0.75s ease-in-out', marginLeft: 'auto' }}
+                style={{ transition: '0.75s ease-in-out'}}
                 {...props}
             />} 
             text={this.getText()}

--- a/app/components/buttons/gallery/SettingsButton.js
+++ b/app/components/buttons/gallery/SettingsButton.js
@@ -13,7 +13,7 @@ export default class SettingsButton extends Component {
     ACTION_REANALYSE    = 1;
     ACTION_CHANGE_MODEL = 2;
 
-    DELETE_MESSAGE = "will <b>delete any and all RSML files</b> in this directory and resubmit images to RootNav API. This requires a working internet connection.\n\nAre you sure you want to do this?"
+    DELETE_MESSAGE = "will <b>delete any and all RSML files</b> in this directory and resubmit images to RootNav API. This requires a working server connection.\n\nAre you sure you want to do this?"
     defaultModel = { description: "Please select a model", value: "" };
 
     constructor(props) {

--- a/app/components/buttons/gallery/SettingsButton.js
+++ b/app/components/buttons/gallery/SettingsButton.js
@@ -6,9 +6,14 @@ import { matchPathName, API_DELETE, writeConfig } from '../../../constants/globa
 import { ipcRenderer } from 'electron';
 import { StyledIcon } from '../../CommonStyledComponents';
 import TooltipOverlay from '../../common/TooltipOverlay';
+import styled from 'styled-components';
 
 export default class SettingsButton extends Component {
-
+    StyledI = styled.i`
+        color: #d9534f;
+        margin-right: 0.25em;
+        font-size: 1.2em;
+    `;
     ACTION_NONE         = 0
     ACTION_REANALYSE    = 1;
     ACTION_CHANGE_MODEL = 2;
@@ -148,7 +153,7 @@ export default class SettingsButton extends Component {
                         }}>
                             Confirm
                     </Button>}
-
+                    {!this.state.confirmText && !this.props.apiStatus ? <span>No server connection found. No images can be analysed <this.StyledI className="fas fa-exclamation-circle"/> </span> : ""}
                     <Button variant="secondary" onClick={e => {         
                         e.stopPropagation();
                         this.cancelAction();

--- a/app/components/buttons/viewer/LeftButton.js
+++ b/app/components/buttons/viewer/LeftButton.js
@@ -7,13 +7,13 @@ export default class LeftButton extends Component {
 
     render() {    
         return (
-            <TooltipOverlay component={ props => <StyledButton
-                    style={{marginRight: "2em"}} 
+            <TooltipOverlay  component={ props => <span className="d-inline-block" {...props}><StyledButton
                     variant="secondary" 
+                    disabled={this.props.disabled}
                     onClick={() => this.props.click(-1)} 
-                    className={`btn btn-default fas fa-arrow-left button`} 
+                    className={`btn btn-default fa fa-arrow-left button`} 
                     {...props}
-                />} 
+                /></span>} 
                 text={"Previous Image"}
             /> 
         )

--- a/app/components/buttons/viewer/ResetChangesButton.js
+++ b/app/components/buttons/viewer/ResetChangesButton.js
@@ -14,6 +14,7 @@ export default class ResetChanges extends Component {
                     style={{pointerEvents: isActive ? 'all' : 'none' }}
                     onClick={() => isActive ? this.props.resetEditStack() : 0} //Cut action if not needed
                     className={`btn btn-default fa fa-trash-restore button`} 
+                    {...props}
                 /></span>
             } 
                 text={"Reset RSML Changes"}

--- a/app/components/buttons/viewer/RightButton.js
+++ b/app/components/buttons/viewer/RightButton.js
@@ -7,12 +7,13 @@ export default class RightButton extends Component {
 
     render() {    
         return (
-            <TooltipOverlay  component={ props => <StyledButton
+            <TooltipOverlay  component={ props => <span className="d-inline-block" {...props}><StyledButton
                     variant="secondary" 
+                    disabled={this.props.disabled}
                     onClick={() => this.props.click(1)} 
-                    className={`btn btn-default fas fa-arrow-right button`} 
+                    className={`btn btn-default fa fa-arrow-right button`} 
                     {...props}
-                />} 
+                /></span>} 
                 text={"Next Image"}
             />    
         )

--- a/app/components/containers/gallery/RefreshButtonContainer.js
+++ b/app/components/containers/gallery/RefreshButtonContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import RefreshButton from '../../buttons/gallery/RefreshButton';
-import { refreshFiles, addFiles, addThumb } from '../../../actions/galleryActions';
+import { refreshFiles, addFiles, addThumb, removeThumb } from '../../../actions/galleryActions';
 
 const mapStateToProps = (state, ownProps) => (
     { 
@@ -14,7 +14,8 @@ const mapDispatchToProps = dispatch => (
     { 
         refreshFiles: files => dispatch(refreshFiles(files)),
         addFiles: (folder, files) => dispatch(addFiles(folder, files)),
-        addThumbs: thumbs => dispatch(addThumb(thumbs))
+        addThumbs: thumbs => dispatch(addThumb(thumbs)),
+        removeThumbs: toRemove => dispatch(removeThumb(toRemove))
     }
 );
 

--- a/app/components/containers/gallery/SettingsButtonContainer.js
+++ b/app/components/containers/gallery/SettingsButtonContainer.js
@@ -7,7 +7,8 @@ const mapStateToProps = (state, ownProps) => ({
     folders: state.gallery.folders,
     apiAddress: state.gallery.apiAddress,
     apiKey: state.gallery.apiKey,
-    apiModels: state.backend.apiModels
+    apiModels: state.backend.apiModels,
+    apiStatus: state.gallery.apiStatus
 });
 
 const mapDispatchToProps = dispatch => (

--- a/app/components/containers/viewer/RenderContainer.js
+++ b/app/components/containers/viewer/RenderContainer.js
@@ -9,7 +9,7 @@ const mapStateToProps = (state, ownProps) => {
     let viewer =  state.viewer.viewers[process.pid];
     return { 
         path: ownProps.path,
-        file: state.gallery.files[path][fileName],
+        file: path && fileName ? state.gallery.files[path][fileName] : null,
         architecture:  viewer ? viewer.architecture : false, //These prevent errors when unloading the viewer, since the action updates children before the process actually ends
         segMasks: viewer ? viewer.segMasks : false,
         editStack: viewer ? viewer.editStack : false

--- a/app/components/containers/viewer/SaveButtonContainer.js
+++ b/app/components/containers/viewer/SaveButtonContainer.js
@@ -8,7 +8,7 @@ const mapStateToProps = (state, ownProps) => {
     let viewer =  state.viewer.viewers[process.pid];
     const { path, fileName }  = matchPathName(ownProps.path);
     return {
-        parsedRSML: state.gallery.files[path][fileName].parsedRSML,
+        parsedRSML: path && fileName ? state.gallery.files[path][fileName].parsedRSML : null,
         editStack: viewer ? viewer.editStack : false,
         path: ownProps.path
     }

--- a/app/components/gallery/FolderView.js
+++ b/app/components/gallery/FolderView.js
@@ -36,12 +36,17 @@ export default class FolderView extends Component {
 
 	componentDidUpdate()
 	{
+		this.checkThumbs();
+	}
+
+	checkThumbs()
+	{
 		const { files, thumbs, isActive } = this.props; 
 		if (isActive && !thumbs && files && !this.state.thumbsGenerating)
 		{
 			this.generateThumbs(files, Object.keys(files))
 		}
-	}
+	};
 
 	spinner = () => {
         const [show, setShow] = useState(false);
@@ -122,6 +127,7 @@ export default class FolderView extends Component {
 				//Refresh button can still manually rescan.
 			});		
 		}
+		this.checkThumbs();
 	}
 
 	render() {

--- a/app/components/gallery/FolderView.js
+++ b/app/components/gallery/FolderView.js
@@ -34,6 +34,15 @@ export default class FolderView extends Component {
 		return (nextProps.isActive !== this.props.isActive) || (JSON.stringify(nextProps.files) !== JSON.stringify(this.props.files));
 	}
 
+	componentDidUpdate()
+	{
+		const { files, thumbs, isActive } = this.props; 
+		if (isActive && !thumbs && files && !this.state.thumbsGenerating)
+		{
+			this.generateThumbs(files, Object.keys(files))
+		}
+	}
+
 	spinner = () => {
         const [show, setShow] = useState(false);
         const target = useRef(null);
@@ -108,16 +117,10 @@ export default class FolderView extends Component {
 					});
 					addFiles(folder, structuredFiles); //Add our struct with the folder as the key to state
 					if (filesToParse.length) ipcRenderer.send(API_PARSE, filesToParse);
-
-					this.generateThumbs(structuredFiles, fileKeys);
 				}
 				this.setState({ read: true }); //Only try read the filesystem once on import. Having no files in a folder would prompt a read, as it won't know if none were found, or if it just hasn't scanned yet
 				//Refresh button can still manually rescan.
 			});		
-		}
-		else if (!thumbs && files && !this.state.thumbsGenerating)
-		{
-			this.generateThumbs(files, Object.keys(files))
 		}
 	}
 

--- a/app/components/gallery/StyledComponents.js
+++ b/app/components/gallery/StyledComponents.js
@@ -16,7 +16,7 @@ export const StyledFolderViewDiv = styled.div` && {
 }`;
     
 export const StyledFilterBarSpan = styled.span` && {
-    width: 30em;
+    width: 27em;
     margin: auto 0 auto 1em;
 }`
 

--- a/app/components/gallery/TopBar.js
+++ b/app/components/gallery/TopBar.js
@@ -5,6 +5,7 @@ import RefreshButton from '../containers/gallery/RefreshButtonContainer';
 import FilterBar from '../containers/gallery/FilterBarContainer'
 import { StyledTopBarDiv, StyledTopBarHR } from '../CommonStyledComponents'
 import ServerIndicator from '../containers/gallery/ServerIndicatorContainer';
+import OpenViewerButton from '../buttons/gallery/OpenViewerButton';
 
 import styled from 'styled-components';
 
@@ -28,7 +29,10 @@ export default class TopBar extends Component {
                         <input type="checkbox" className="custom-control-input" id="drawRsml" defaultChecked={true} onClick={this.props.toggleArch}/>
                         <label className="custom-control-label" htmlFor="drawRsml">Draw Architecture</label>
                     </this.labelDiv>
-                    <ServerIndicator />
+                    <div style={{ marginLeft: 'auto' }} >
+                        <OpenViewerButton />
+                        <ServerIndicator />
+                    </div>
                 </StyledTopBarDiv>
                 <StyledTopBarHR/>
             </div>

--- a/app/components/viewer/FolderChecklist.js
+++ b/app/components/viewer/FolderChecklist.js
@@ -10,7 +10,7 @@ export default class FolderChecklist extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            checked: [props.path],
+            checked: props.path ? [props.path] : [],
             expanded: [],
             nodes: []
         };

--- a/app/components/viewer/PluginBar.js
+++ b/app/components/viewer/PluginBar.js
@@ -269,10 +269,10 @@ export default class PluginBar extends Component {
             const pluginFilenames = readdirSync(PLUGINDIR); // Get all plugin filenames
             pluginFilenames.forEach(filename => {
                 if (!filename.match(/.+?(?:js|ts|jsx)$/)) return; //if it's not a js file, we don't want to use it.
-                const plugin = _require(`${PLUGINDIR}${filename.replace('.js', '')}`); // For each filename, import the plugin
+                const plugin = _require(`${PLUGINDIR}${filename.replace(/.+?(:js|ts|jsx)$/, '')}`); // For each filename, import the plugin
                 
-                if (["name", "group", "function", "description"].every(param => param in plugin)) { // If the plugins have all the necessary members, then add it to the plugins object.
-                    // Todo good typechecking
+                if (["name", "group", "function", "description"].every(param => param in plugin) && this.pluginTypeCheck(plugin)) { // If the plugins have all the necessary members, then add it to the plugins object.
+
                     if (!(plugin.group in plugins)) plugins[plugin.group] = {}; // Initialise empty object for group
                     plugins[plugin.group][plugin.name] = { "function": plugin.function, "active": false, description: plugin.description };
                 }
@@ -281,6 +281,10 @@ export default class PluginBar extends Component {
         }
         return plugins;
     }
+
+    // Requires a valid plugin object (correct object keys) be passed in, and returns if the types of all these keys are correct.
+    pluginTypeCheck = plugin => typeof plugin.name === "string" && typeof plugin.group === "string" 
+                                && typeof plugin.description === "string" && typeof plugin.function === 'function';
 
     togglePlugin = (groupName, pluginName) => {
         const { plugins } = this.state;

--- a/app/components/viewer/PluginBar.js
+++ b/app/components/viewer/PluginBar.js
@@ -16,7 +16,8 @@ import utils from '../../constants/pluginUtils';
 import cloneDeep from 'lodash.clonedeep';
 
 export default class PluginBar extends Component {
-    
+    csvPath = "";
+
     constructor(props) 
     {
         super(props);
@@ -32,7 +33,7 @@ export default class PluginBar extends Component {
         };
         this.exportDest = React.createRef();
     }
-
+    
     getGroupsFromPlugins = plugins => Object.fromEntries(Object.keys(plugins).map(group => [group, true]));
 
     deactivateAllPlugins = () => {
@@ -225,7 +226,7 @@ export default class PluginBar extends Component {
                         path,
                         header: headers[type]
                     });
-                    csvWriter.writeRecords(data[type]).then(() => console.log(`written to ${path}`));
+                    csvWriter.writeRecords(data[type]).then(() => { this.csvPath = path; console.log(`written to ${path}`) });
                 }
             });
             setTimeout(() => this.setState({ ...this.state, measuresComplete: true }), 225); //Tiny delay for the animation change so it doesn't collide with the collapse and get missed.
@@ -313,6 +314,6 @@ export default class PluginBar extends Component {
     };
 
     openContainingDirectory = () => {
-        shell.showItemInFolder(this.exportDest.current.value);
+        shell.showItemInFolder(this.csvPath);
     }
 }

--- a/app/components/viewer/Render.js
+++ b/app/components/viewer/Render.js
@@ -12,7 +12,7 @@ export default class Render extends Component {
     constructor(props)
     {
         super(props);
-        this.canvasID = [...Array(5)].map(() => Math.random().toString(36)[2]).join(''); //Make a random canvas ID so we can open multiple and recreating isn't a problem
+        this.canvasID = [...Array(8)].map(() => Math.random().toString(36)[2]).join(''); //Make a random canvas ID so we can open multiple and recreating isn't a problem
         this.fabricCanvas = new fabric.Canvas(this.canvasID, { fireRightClick: true, targetFindTolerance: 15, selection: false }); //Extra pixels around an object the canvas includes in hitbox
         this.imageSize = {};
     }

--- a/app/components/viewer/Render.js
+++ b/app/components/viewer/Render.js
@@ -211,8 +211,8 @@ export default class Render extends Component {
 
     draw = () => {
         const { file, path, architecture, segMasks, updateFile, editStack } = this.props;
-        
-        if (file.parsedRSML) //Ready to draw!
+        console.log("file", file);
+        if (file && file.parsedRSML) //Ready to draw!
         {
             //If there's something on the edit stack, grab the last one, else we use the file state RSML
             const polylines = editStack.length ? editStack[editStack.length - 1] : file.parsedRSML.polylines;
@@ -225,7 +225,6 @@ export default class Render extends Component {
 
             // Save image size, for scaling usage!;
             this.imageSize = sizeOf(path + sep + fileName + "." + ext);
-
 
             if (segMasks && file._C1 && file._C2) //Composite the segmasks together
                 if (!file.seg_mask) 
@@ -265,7 +264,7 @@ export default class Render extends Component {
             let polyline = new fabric.Polyline(line.points, {
                 stroke: line.type == 'primary' ? COLOURS.PRIMARY : COLOURS.LATERAL,
                 fill: null,
-                strokeWidth: 4,
+                strokeWidth: 6,
                 perPixelTargetFind: true,
                 name: line.id,
                 lockMovementX: true,

--- a/app/components/viewer/Render.js
+++ b/app/components/viewer/Render.js
@@ -211,7 +211,6 @@ export default class Render extends Component {
 
     draw = () => {
         const { file, path, architecture, segMasks, updateFile, editStack } = this.props;
-        console.log("file", file);
         if (file && file.parsedRSML) //Ready to draw!
         {
             //If there's something on the edit stack, grab the last one, else we use the file state RSML

--- a/app/components/viewer/TopBar.js
+++ b/app/components/viewer/TopBar.js
@@ -19,28 +19,31 @@ export default class TopBar extends Component {
         let tag = path ? splitPath.fileName : ""; //Matches the file path into the absolute directory path and file name
         const folderFiles = this.props.files[splitPath.path];
 
-        const noRSMLInFolder = !Object.values(folderFiles).some(file => file.parsedRSML);
+        const noRSMLInFolder = folderFiles && !Object.values(folderFiles).some(file => file.parsedRSML);
+
+        let message = ""
+        if (noRSMLInFolder) 
+            message = <b>"No RSML found in Folder"</b>;
+        else if (folderFiles) 
+            message = <><b>Open Image: </b>{`${Object.keys(folderFiles).indexOf(tag) + 1} of ${Object.keys(folderFiles).length}`}</>
+
         return (
             <div>
                 <StyledTopBarDiv data-tid="container">
-                    <StyledRow>
+                    <StyledRow>{ folderFiles ? <>
                         <div className="col-sm-4"><b>Tag:</b> {tag}</div>
-                        <div className="col-sm-2">{
-                            noRSMLInFolder ? <b>No RSML found in Folder</b> : <>
-                                <b>Open Image: </b> 
-                                {Object.keys(folderFiles).indexOf(tag) + 1} of {Object.keys(folderFiles).length}
-                                <TooltipOverlay  component={ props => <StyledIcon
-                                        className={"fas fa-info-circle"}
-                                        {...props}
-                                    />} 
-                                    text={"Any images with missing RSML vice versa will be skipped."} // Temporary solution
-                                    placement={"bottom"}
-                                /> 
-                            </>
-                        }</div>
+                        <div className="col-sm-2">{message}
+                            <TooltipOverlay component={ props => <StyledIcon
+                                    className={"fas fa-info-circle"}
+                                    {...props}
+                                />} 
+                                text={"Any images with missing RSML vice versa will be skipped."} // Temporary solution
+                                placement={"bottom"}
+                            /> 
+                        </div>
                         <div className="col-sm-3"><b>Analysis Date:</b> {date}</div>
                         <div className="col-sm-3"><b>Number of Plants:</b> {plants}</div>
-                    </StyledRow>
+                    </> : <><b>No Images Loaded:</b>&nbsp;{"Please select a folder on the left hand side to open."}</>}</StyledRow>
                 </StyledTopBarDiv>
                 <StyledTopBarHR/>
                 <StyledTopBarDiv className="d-inline-flex container" data-tid="container" style={{paddingTop: '0', minWidth: '100%'}}>
@@ -56,8 +59,8 @@ export default class TopBar extends Component {
                             </div>
                         </div>
                         <div className="col-4" style={{textAlign: "center"}}>
-                            <LeftButton click={buttonHandler}/>
-                            <RightButton click={buttonHandler}/>
+                            <LeftButton click={buttonHandler} disabled={!folderFiles}/>
+                            <RightButton click={buttonHandler} disabled={!folderFiles}/>
                         </div>
                         <div className="col-4" style={{textAlign: "right"}}>
                             <ResetChangesButton />

--- a/app/components/viewer/TopBar.js
+++ b/app/components/viewer/TopBar.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { Component } from 'react';
-import { StyledTopBarDiv, StyledTopBarHR } from '../CommonStyledComponents'
+import { StyledTopBarDiv, StyledTopBarHR, StyledIcon } from '../CommonStyledComponents'
 import LeftButton from '../buttons/viewer/LeftButton';
 import RightButton from '../buttons/viewer/RightButton';
 import ResetChangesButton from '../containers/viewer/ResetButtonContainer';
@@ -8,6 +8,7 @@ import SaveRSMLButton from '../containers/viewer/SaveButtonContainer';
 import UndoChangesButton from '../containers/viewer/UndoButtonContainer';
 import { StyledRow } from './StyledComponents';
 import { matchPathName } from '../../constants/globals';
+import TooltipOverlay from '../common/TooltipOverlay';
 import { Row } from 'react-bootstrap';
 
 export default class TopBar extends Component {
@@ -25,7 +26,17 @@ export default class TopBar extends Component {
                     <StyledRow>
                         <div className="col-sm-4"><b>Tag:</b> {tag}</div>
                         <div className="col-sm-2">{
-                            noRSMLInFolder ? <b>No RSML found in Folder</b> : <><b>Open Image:</b> {Object.keys(folderFiles).indexOf(tag) + 1} of {Object.keys(folderFiles).length}</>
+                            noRSMLInFolder ? <b>No RSML found in Folder</b> : <>
+                                <b>Open Image: </b> 
+                                {Object.keys(folderFiles).indexOf(tag) + 1} of {Object.keys(folderFiles).length}
+                                <TooltipOverlay  component={ props => <StyledIcon
+                                        className={"fas fa-info-circle"}
+                                        {...props}
+                                    />} 
+                                    text={"Any images with missing RSML vice versa will be skipped."} // Temporary solution
+                                    placement={"bottom"}
+                                /> 
+                            </>
                         }</div>
                         <div className="col-sm-3"><b>Analysis Date:</b> {date}</div>
                         <div className="col-sm-3"><b>Number of Plants:</b> {plants}</div>

--- a/app/components/viewer/TopBar.js
+++ b/app/components/viewer/TopBar.js
@@ -50,7 +50,7 @@ export default class TopBar extends Component {
                     <Row style={{width: "100%"}}>
                         <div className="col-4" style={{display: "-webkit-box"}}>
                             <div className="custom-control custom-checkbox" style={{margin: 'auto 0 auto 1em', width: "auto"}}>
-                                <input type="checkbox" className="custom-control-input" id="architecture" defaultChecked={true} onClick={this.props.toggleArch} />
+                                <input type="checkbox" className="custom-control-input" disabled={!folderFiles} id="architecture" defaultChecked={true} onClick={this.props.toggleArch} />
                                 <label className="custom-control-label" htmlFor="architecture">Architecture</label>
                             </div>
                             <div className="custom-control custom-checkbox" style={{margin: 'auto 1em auto 1em'}}>

--- a/app/components/viewer/Viewer.js
+++ b/app/components/viewer/Viewer.js
@@ -17,7 +17,7 @@ export default class Viewer extends Component {
     {
         super(props);
         const { addViewer, removeViewer, path } = props;
-        this.state = { path: (path == null ? null : path ), redFolderBorder: false };
+        this.state = { path: (!path ? null : path ), redFolderBorder: false };
         
         addViewer();
         remote.getCurrentWindow().on('close', () => { //These will cause memory leaks in prod if lots of viewers get opened
@@ -95,6 +95,7 @@ export default class Viewer extends Component {
     };
 
     hasSegMasks = () => {
+        if (!this.state.path) return false;
         let { path, fileName } = matchPathName(this.state.path);
         const file = this.props.files[path][fileName];
         return file.hasOwnProperty("_C1") && file.hasOwnProperty("_C2");
@@ -125,7 +126,7 @@ export default class Viewer extends Component {
             <StyledContainer>
                 <TopBar path={path} date={this.getDate(rsml)} hasSegMasks={this.hasSegMasks()} buttonHandler={this.loadNextRSML} plants={this.getNumberOfPlants(rsml)}/>
                 <StyledSidebarContainer>
-                    <FolderChecklist path={matchPathName(path).path} updatePath={this.updatePath} redFolderBorder={redFolderBorder}/>
+                    <FolderChecklist path={matchedPath ? matchedPath.path : null} updatePath={this.updatePath} redFolderBorder={redFolderBorder}/>
                     <Render path={path}/>
                     <PluginBar toggleFolderBorder={this.toggleFolderBorder}/>
                 </StyledSidebarContainer>

--- a/app/constants/globals.js
+++ b/app/constants/globals.js
@@ -41,7 +41,7 @@ export const COLOURS = { PRIMARY: '#f53', LATERAL: '#ffff00', HOVERED: 'white' }
 
 export const DEFAULT_CONFIG = { apiAddress: "", apiKey: "", folders: [] };
 
-export const matchPathName = path => path.match(/(?<path>.+)(?:\\|\/)(?<fileName>.+)/).groups || { path: "", fileName: "" }; //Matches the file's dir path and actual name. no trailing slash on the path
+export const matchPathName = path => (path && path.match(/(?<path>.+)(?:\\|\/)(?<fileName>.+)/).groups) || { path: "", fileName: "" }; //Matches the file's dir path and actual name. no trailing slash on the path
 
 export const getProcessTypeFromURL = url => {
     const groups = url.match(/\/app.html\?(?<name>[a-z]*)/).groups;

--- a/app/constants/globals.js
+++ b/app/constants/globals.js
@@ -15,6 +15,7 @@ export const CONFIG     = 'config.json';
 export const API_DELETE = 'api-delete';
 export const API_PARSE  = 'api-parse';
 export const CLOSE_VIEWER = 'close-viewer';
+export const IMAGES_REMOVED_FROM_GALLERY = 'images-removed-from-gallery';
 export const NOTIFICATION_CLICKED = 'NOTIFICATION_CLOSED';
 export const HTTP_PORT = 9000;
 
@@ -87,7 +88,7 @@ export const sendThumbs = (thumbs, addThumbs) => {
         get(`http://127.0.0.1:${HTTP_PORT}/health`).then(res => {
             post(`http://127.0.0.1:${HTTP_PORT}/thumb`, thumbs).then(res => resolve(addThumbs(res.data))).catch(err => setTimeout(() => resolve(sendThumbs(thumbs, addThumbs)), 2000)); //If Axios hangs up, try again.
         }).catch(err => setTimeout(() => resolve(sendThumbs(thumbs, addThumbs)), 5000)); //If backend isn't up yet, wait 5s and try again.
-        //Add some limit to this, in case firewalls or similar block local HTTP server, in which case we have a big problem.
+        //Add some limit to this, in case firewalls or similar block local HTTP server, in which case we have a big problem. TODO
     });
 };
 defaults.adapter = _require('axios/lib/adapters/http'); //Axios will otherwise default to the XHR adapter due to being in an Electron browser, and won't work.

--- a/app/constants/globals.js
+++ b/app/constants/globals.js
@@ -38,7 +38,7 @@ export const API_POLLTIME  = 1000 * 5; //API poll interval in milliseconds
 export const THUMB_PERCENTAGE = 15;
 export const COLOURS = { PRIMARY: '#f53', LATERAL: '#ffff00', HOVERED: 'white' };
 
-export const DEFAULT_CONFIG = { apiAdrdress: "", apiKey: "", folders: [] };
+export const DEFAULT_CONFIG = { apiAddress: "", apiKey: "", folders: [] };
 
 export const matchPathName = path => path.match(/(?<path>.+)(?:\\|\/)(?<fileName>.+)/).groups || { path: "", fileName: "" }; //Matches the file's dir path and actual name. no trailing slash on the path
 

--- a/app/constants/globals.js
+++ b/app/constants/globals.js
@@ -40,7 +40,7 @@ export const COLOURS = { PRIMARY: '#f53', LATERAL: '#ffff00', HOVERED: 'white' }
 
 export const DEFAULT_CONFIG = { apiAdrdress: "", apiKey: "", folders: [] };
 
-export const matchPathName = path => path.match(/(?<path>.+)(?:\\|\/)(?<fileName>.+)/).groups; //Matches the file's dir path and actual name. no trailing slash on the path
+export const matchPathName = path => path.match(/(?<path>.+)(?:\\|\/)(?<fileName>.+)/).groups || { path: "", fileName: "" }; //Matches the file's dir path and actual name. no trailing slash on the path
 
 export const getProcessTypeFromURL = url => {
     const groups = url.match(/\/app.html\?(?<name>[a-z]*)/).groups;

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -17,7 +17,7 @@ import { WINDOW_HEIGHT, WINDOW_WIDTH, API_DELETE, API_PARSE, CLOSE_VIEWER, NOTIF
 import { join } from 'path';
 const { autoUpdater } = require('electron-updater');
 
-if (app.isPackaged)
+if (process.platform == 'win32' && app.isPackaged)
 {
     autoUpdater.checkForUpdatesAndNotify();
 }

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -17,9 +17,6 @@ import { WINDOW_HEIGHT, WINDOW_WIDTH, API_DELETE, API_PARSE, CLOSE_VIEWER, NOTIF
 import { join } from 'path';
 const { autoUpdater } = require('electron-updater');
 
-const bUpdate = false;
-let dialogOpts;
-
 if (app.isPackaged)
 {
     autoUpdater.checkForUpdatesAndNotify();

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -13,7 +13,7 @@
 import { app, BrowserWindow, ipcMain, dialog, Tray, Menu } from 'electron';
 import Store from './store/configureStore';
 const { configureStore } = Store('main'); //Import is a func that sets the type of history based on the process scope calling it and returns the store configurer
-import { WINDOW_HEIGHT, WINDOW_WIDTH, API_DELETE, API_PARSE, CLOSE_VIEWER, NOTIFICATION_CLICKED, UPDATE_READY } from './constants/globals';
+import { WINDOW_HEIGHT, WINDOW_WIDTH, API_DELETE, API_PARSE, CLOSE_VIEWER, NOTIFICATION_CLICKED, IMAGES_REMOVED_FROM_GALLERY } from './constants/globals';
 import { join } from 'path';
 const { autoUpdater } = require('electron-updater');
 
@@ -219,9 +219,13 @@ ipcMain.on('getExportDest', event => {
     });
 });
 
-ipcMain.on(CLOSE_VIEWER, (event, path) => {
-    BrowserWindow.getAllWindows().forEach(window => window.webContents.send(CLOSE_VIEWER, path));
-});
+ipcMain.on(CLOSE_VIEWER, (event, path) => relayToAllViewer(CLOSE_VIEWER, path));
+
+ipcMain.on(IMAGES_REMOVED_FROM_GALLERY, (event, info) => relayToAllViewer(IMAGES_REMOVED_FROM_GALLERY, info));
+
+const relayToAllViewer = (event, data) => {
+    BrowserWindow.getAllWindows().forEach(window => window.webContents.send(event, data));
+}
 
 /**********************
 **  Open Viewer Event

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -239,7 +239,7 @@ ipcMain.on('openViewer', (event, path) => {
         },
         devTools: process.env.NODE_ENV === 'production' ? false : true
     }); 
-    subWindow.loadURL(`file://${__dirname}/app.html?viewer?${path}`);
+    subWindow.loadURL(`file://${__dirname}/app.html?viewer?${path || ""}`);
 
     subWindow.webContents.on('did-finish-load', () => {
         if (!subWindow) return subWindow = null;

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -13,16 +13,19 @@
 import { app, BrowserWindow, ipcMain, dialog, Tray, Menu } from 'electron';
 import Store from './store/configureStore';
 const { configureStore } = Store('main'); //Import is a func that sets the type of history based on the process scope calling it and returns the store configurer
-import { WINDOW_HEIGHT, WINDOW_WIDTH, API_DELETE, API_PARSE, CLOSE_VIEWER, NOTIFICATION_CLICKED } from './constants/globals';
+import { WINDOW_HEIGHT, WINDOW_WIDTH, API_DELETE, API_PARSE, CLOSE_VIEWER, NOTIFICATION_CLICKED, UPDATE_READY } from './constants/globals';
 import { join } from 'path';
+const { autoUpdater } = require('electron-updater');
 
-// export default class AppUpdater {
-//   constructor() {
-//     log.transports.file.level = 'info';
-//     autoUpdater.logger = log;
-//     autoUpdater.checkForUpdatesAndNotify();
-//   }
-// }
+const bUpdate = false;
+let dialogOpts;
+
+if (app.isPackaged)
+{
+    autoUpdater.checkForUpdatesAndNotify();
+}
+
+console.log("I am version: " + app.getVersion());
 
 const CLOSE = 0;
 const BACKGROUND = 1;
@@ -30,7 +33,7 @@ let closeFlag; //Hack - app.quit causes the close event to fire again, so we nee
 let appIcon = null; //Orphan variable required so the icon doesn't get GC'd by V8
 let mainWindow = null;
 let backendWindow = null;
-let iconClick = () => mainWindow ? mainWindow.focus() : openGallery();
+const iconClick = () => mainWindow ? mainWindow.focus() : openGallery();
 
 /**********************
 **  Open the Gallery

--- a/app/reducers/galleryReducer.js
+++ b/app/reducers/galleryReducer.js
@@ -1,5 +1,5 @@
 import { OPEN_DIR, REFRESH_DIRS, REMOVE_DIR, TOGGLE_DIR, CLOSE_MODAL, SHOW_MODAL, UPDATE_MODAL, 
-    IMPORT_CONFIG, UPDATE_CHECKED, ADD_FILES, ADD_THUMB, UPDATE_FILTER_TEXT, UPDATE_FILTER_ANALYSED, 
+    IMPORT_CONFIG, UPDATE_CHECKED, ADD_FILES, ADD_THUMB, REMOVE_THUMB, UPDATE_FILTER_TEXT, UPDATE_FILTER_ANALYSED, 
     UPDATE_PARSED_RSML, UPDATE_CHECKLIST_DROPDOWN, UPDATE_FOLDER_MODEL, UPDATE_FILE, RESET_FOLDER, 
     TOGGLE_LABELS, TOGGLE_GALLERY_ARCH, SAVE_API_SETTINGS, UPDATE_API_STATUS, UPDATE_API_MODAL, UPDATE_API_AUTH } from '../actions/galleryActions';
 
@@ -69,19 +69,33 @@ export default (state = initialState, action) => {
         //action.thumb = [{ folder: "C:\Andrew\Desktop\rsml", fileName: "wheat_1", ext: "png", thumb: {type: "Buffer", data: [x, x, x,]}, {...}}
         case ADD_THUMB: {
             return {
-            ...state,
-            thumbs: {
-                ...state.thumbs,
-                ...action.thumbs.reduce((acc, obj) => ({
-                    ...acc, 
-                    [obj.folder]: {
-                        ...(state.thumbs[obj.folder] || {}),
-                        ...(acc[obj.folder] || {}),
-                        [obj.fileName]: obj.thumb
-                    }
-                }), {})
+                ...state,
+                thumbs: {
+                    ...state.thumbs,
+                    ...action.thumbs.reduce((acc, obj) => ({
+                        ...acc, 
+                        [obj.folder]: {
+                            ...(state.thumbs[obj.folder] || {}),
+                            ...(acc[obj.folder] || {}),
+                            [obj.fileName]: obj.thumb
+                        }
+                    }), {})
+                }
             }
         }
+        case REMOVE_THUMB: return {
+                ...state,
+                thumbs: {
+                    ...Object.fromEntries(
+                        Object.entries(state.thumbs).reduce((acc, folder) => ([
+                            ...acc,
+                            [folder[0], Object.fromEntries(
+                                Object.entries(folder[1])
+                                    .filter(file => !action.toRemove.some(it => it.folder == folder[0] && it.filename == file[0]))
+                            )]
+                        ]), [])
+                    )
+                }
         }
         case UPDATE_FILTER_TEXT: return {
             ...state,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rootnav-portal",
   "productName": "RootNav-Portal",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Root system viewer",
   "scripts": {
     "build": "concurrently \"yarn build-main\" \"yarn build-renderer\"",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rootnav-portal",
   "productName": "RootNav-Portal",
-  "version": "0.5.0",
+  "version": "0.5.3",
   "description": "Root system viewer",
   "scripts": {
     "build": "concurrently \"yarn build-main\" \"yarn build-renderer\"",
@@ -22,6 +22,8 @@
     "package-linux": "yarn build && electron-builder build --linux",
     "package-mac": "yarn build && electron-builder build --mac",
     "package-win": "yarn build && electron-builder build --win --x64",
+    "deploy-mac": "yarn build && electron-builder build -p always --mac",
+    "deploy-win": "yarn build && electron-builder build -p always --win --x64",
     "postinstall": "electron-builder install-app-deps && yarn build-dll && opencollective-postinstall",
     "postlint-fix": "prettier --ignore-path .eslintignore --single-quote --write '**/*.{*{js,jsx,json},babelrc,eslintrc,prettierrc,stylelintrc}'",
     "postlint-styles-fix": "prettier --ignore-path .eslintignore --single-quote --write '**/*.{css,scss}'",
@@ -58,7 +60,7 @@
   "main": "./app/main.prod.js",
   "build": {
     "productName": "RootNav Portal",
-    "appId": "org.uon.RootNav",
+    "appId": "com.uon.RootNav",
     "files": [
       "app/dist/",
       "node_modules/",
@@ -105,8 +107,7 @@
     },
     "win": {
       "target": [
-        "nsis",
-        "portable"
+        "nsis"
       ]
     },
     "linux": {
@@ -125,8 +126,7 @@
     "publish": {
       "provider": "github",
       "owner": "Chagrilled",
-      "repo": "RootNavPortal",
-      "private": true
+      "repo": "RootNavPortal"
     }
   },
   "repository": {
@@ -298,7 +298,7 @@
     "dree": "^2.1.11",
     "electron-debug": "^3.0.1",
     "electron-log": "^4.0.0",
-    "electron-updater": "^4.1.2",
+    "electron-updater": "^4.2.5",
     "fabric": "^4.0.0-beta.7",
     "fastify": "^2.13.0",
     "form-data": "^3.0.0",
@@ -322,6 +322,7 @@
     "source-map-support": "^0.5.16",
     "styled-components": "^5.0.1",
     "tiff.js": "^1.0.0",
+    "update-electron-app": "^1.5.0",
     "xml2json": "https://github.com/chagrilled/node-xml2json"
   },
   "devEngines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1374,10 +1374,12 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/semver@^6.0.2":
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
-  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
+"@types/semver@^7.1.0":
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.1.0.tgz#c8c630d4c18cd326beff77404887596f96408408"
+  integrity sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==
+  dependencies:
+    "@types/node" "*"
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -3421,14 +3423,6 @@ buffers@~0.1.1:
   resolved "https://registry.yarnpkg.com/buffers/-/buffers-0.1.1.tgz#b24579c3bed4d6d396aeee6d9a8ae7f5482ab7bb"
   integrity sha1-skV5w77U1tOWru5tmorn9Ugqt7s=
 
-builder-util-runtime@8.4.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.4.0.tgz#3163fffc078e6b8f3dd5b6eb12a8345573590682"
-  integrity sha512-CJB/eKfPf2vHrkmirF5eicVnbDCkMBbwd5tRYlTlgud16zFeqD7QmrVUAOEXdnsrcNkiLg9dbuUsQKtl/AwsYQ==
-  dependencies:
-    debug "^4.1.1"
-    sax "^1.2.4"
-
 builder-util-runtime@8.6.2:
   version "8.6.2"
   resolved "https://registry.yarnpkg.com/builder-util-runtime/-/builder-util-runtime-8.6.2.tgz#8270e15b012d8d3b110f3e327b0fd8b0e07b1686"
@@ -5332,6 +5326,11 @@ electron-is-accelerator@^0.1.0:
   resolved "https://registry.yarnpkg.com/electron-is-accelerator/-/electron-is-accelerator-0.1.2.tgz#509e510c26a56b55e17f863a4b04e111846ab27b"
   integrity sha1-UJ5RDCala1Xhf4Y6SwThEYRqsns=
 
+electron-is-dev@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-0.3.0.tgz#14e6fda5c68e9e4ecbeff9ccf037cbd7c05c5afe"
+  integrity sha1-FOb9pcaOnk7L7/nM8DfL18BcWv4=
+
 electron-is-dev@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/electron-is-dev/-/electron-is-dev-1.1.0.tgz#b15a2a600bdc48a51a857d460e05f15b19a2522c"
@@ -5386,19 +5385,19 @@ electron-to-chromium@^1.3.295, electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz#e8265301d053d5f74e36cb876486830261fbe946"
   integrity sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==
 
-electron-updater@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-4.2.0.tgz#f9ecfc657f65ead737d42b9efecf628d3756b550"
-  integrity sha512-GuS3g7HDh17x/SaFjxjswlWUaKHczksYkV2Xc5CKj/bZH0YCvTSHtOmnBAdAmCk99u/71p3zP8f0jIqDfGcjww==
+electron-updater@^4.2.5:
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/electron-updater/-/electron-updater-4.2.5.tgz#dbced8da6f8c6fc2dc662f2776131f5a49ce018d"
+  integrity sha512-ir8SI3capF5pN4LTQY79bP7oqiBKjgtdDW378xVId5VcGUZ+Toei2j+fgx1mq3y4Qg19z4HqLxEZ9FqMD0T0RA==
   dependencies:
-    "@types/semver" "^6.0.2"
-    builder-util-runtime "8.4.0"
+    "@types/semver" "^7.1.0"
+    builder-util-runtime "8.6.2"
     fs-extra "^8.1.0"
     js-yaml "^3.13.1"
     lazy-val "^1.0.4"
     lodash.isequal "^4.5.0"
-    pako "^1.0.10"
-    semver "^6.3.0"
+    pako "^1.0.11"
+    semver "^7.1.3"
 
 electron@^8.2.1:
   version "8.2.1"
@@ -6895,6 +6894,13 @@ github-from-package@0.0.0:
   resolved "https://registry.yarnpkg.com/github-from-package/-/github-from-package-0.0.0.tgz#97fb5d96bfde8973313f20e8288ef9a167fa64ce"
   integrity sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=
 
+github-url-to-object@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/github-url-to-object/-/github-url-to-object-4.0.4.tgz#a9797b7026e18d53b50b07f45b7e169b55fd90ee"
+  integrity sha512-1Ri1pR8XTfzLpbtPz5MlW/amGNdNReuExPsbF9rxLsBfO1GH9RtDBamhJikd0knMWq3RTTQDbTtw0GGvvEAJEA==
+  dependencies:
+    is-url "^1.1.0"
+
 glob-base@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-base/-/glob-base-0.3.0.tgz#dbb164f6221b1c0b1ccf82aea328b497df0ea3c4"
@@ -8386,6 +8392,11 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
+is-url@^1.1.0, is-url@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/is-url/-/is-url-1.2.4.tgz#04a4df46d28c4cff3d73d01ff06abeb318a1aa52"
+  integrity sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==
 
 is-utf8@^0.2.0:
   version "0.2.1"
@@ -10997,7 +11008,12 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-pako@^1.0.10, pako@~1.0.5:
+pako@^1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
+pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
@@ -15208,6 +15224,16 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
   integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
+update-electron-app@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/update-electron-app/-/update-electron-app-1.5.0.tgz#492cb904db07a0b28dbd83fb52e0fe500bbe3463"
+  integrity sha512-g7noW9JfQ8Hwq6zw9lmZei+R/ikOIBcaZ04TbmIcU5zNfv23HkN80QLLAyiR/47KvfS4sjnh2/wuDq5nh8+0mQ==
+  dependencies:
+    electron-is-dev "^0.3.0"
+    github-url-to-object "^4.0.4"
+    is-url "^1.2.4"
+    ms "^2.1.1"
 
 update-notifier@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
# 0.6.0:
- Added auto-updates for Windows. App will download, notify, and update on close
- Moved thumbnail generation to upon opening a folder to reduce potentially unnecessary loading/storing of folders that may not be opened.
- Added an 'About' page to document maintainer contacts, suggestion/bug link, version and internals
- Added 'Open Viewer' button to gallery, and added state to viewer if nothing is open.
- Added type checking for plugins.
- Modified message dialog when closing the gallery while images are still processing.
- Added separator to icon menu.
- Re-added missing util function `splitLinesAsPlants`.
- Added tooltip to explain why images are being skipped in viewer page
- Fixed potential crash when importing non .js plugins.
- Fixed a bug which caused newly imported folders to not update in the viewer page until another action was made
- Fixed a bug causing thumbnails to not refresh after background app
- Fixed a bug causing the export "Open" button being unable to find a written file when exporting multiple
- Fixed a crash when navigating the viewer into an RSML without an image
- Fixed mutliple crashes and exceptions relating to refreshing the gallery page
- Fixed crash where deleting an image from the file system and then refreshing would crash viewer if that image was currently open
- Fixed bug when switching folders in the viewer can crash if the first tag has no image or RSML